### PR TITLE
Add support for setMulti and quiet commands

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,6 +1,7 @@
 package memcache
 
 import (
+	"fmt"
 	"runtime"
 	"strings"
 	"sync"
@@ -44,6 +45,132 @@ func benchmarkSetGet(b *testing.B, item *Item) {
 	cmd.Wait()
 }
 
+func benchmarkSetQuietly(b *testing.B, item *Item) {
+	cmd, c := newUnixServer(b)
+	c.SetTimeout(time.Duration(-1))
+	b.SetBytes(int64(len(item.Key) + len(item.Value)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.SetQuietly(item); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	cmd.Process.Kill()
+	cmd.Wait()
+}
+
+func benchmarkSetGetQuietly(b *testing.B, item *Item) {
+	cmd, c := newUnixServer(b)
+	c.SetTimeout(time.Duration(-1))
+	key := item.Key
+	b.SetBytes(int64(len(item.Key) + len(item.Value)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.SetQuietly(item); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := c.Get(key); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	cmd.Process.Kill()
+	cmd.Wait()
+}
+
+func benchmarkSetMulti(b *testing.B, items []*Item) {
+	cmd, c := newUnixServer(b)
+	c.SetTimeout(time.Duration(-1))
+	bytes := 0
+	for _, item := range items {
+		bytes += len(item.Key) + len(item.Value)
+	}
+	b.SetBytes(int64(bytes))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.SetMulti(items); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	cmd.Process.Kill()
+	cmd.Wait()
+}
+
+func benchmarkSetGetMulti(b *testing.B, items []*Item) {
+	cmd, c := newUnixServer(b)
+	c.SetTimeout(time.Duration(-1))
+	keys := make([]string, len(items))
+	bytes := 0
+	for i, item := range items {
+		bytes += len(item.Key) + len(item.Value)
+		keys[i] = item.Key
+	}
+	b.SetBytes(int64(bytes))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.SetMulti(items); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := c.GetMulti(keys); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	cmd.Process.Kill()
+	cmd.Wait()
+}
+
+func benchmarkSetMultiQuietly(b *testing.B, items []*Item) {
+	cmd, c := newUnixServer(b)
+	c.SetTimeout(time.Duration(-1))
+	bytes := 0
+	for _, item := range items {
+		bytes += len(item.Key) + len(item.Value)
+	}
+	b.SetBytes(int64(bytes))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.SetMultiQuietly(items); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	cmd.Process.Kill()
+	cmd.Wait()
+}
+
+func benchmarkSetGetMultiQuietly(b *testing.B, items []*Item) {
+	cmd, c := newUnixServer(b)
+	c.SetTimeout(time.Duration(-1))
+	keys := make([]string, len(items))
+	bytes := 0
+	for i, item := range items {
+		bytes += len(item.Key) + len(item.Value)
+		keys[i] = item.Key
+	}
+	b.SetBytes(int64(bytes))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := c.SetMultiQuietly(items); err != nil {
+			b.Fatal(err)
+		}
+		if _, err := c.GetMulti(keys); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	cmd.Process.Kill()
+	cmd.Wait()
+}
+
 func largeItem() *Item {
 	key := strings.Repeat("f", 240)
 	value := make([]byte, 1024)
@@ -52,6 +179,26 @@ func largeItem() *Item {
 
 func smallItem() *Item {
 	return &Item{Key: "foo", Value: []byte("bar")}
+}
+
+func generateSmallItems(count int) []*Item {
+	items := make([]*Item, count)
+	for i := 0; i < count; i++ {
+		key := fmt.Sprintf("foo_%d", i)
+		items[i] = &Item{Key: key, Value: []byte("bar")}
+	}
+	return items
+}
+
+func generateLargeItems(count int) []*Item {
+	items := make([]*Item, count)
+	for i := 0; i < count; i++ {
+		suffix := fmt.Sprintf("_%d", i)
+		key := strings.Repeat("f", 240 - len(suffix))
+		value := make([]byte, 1024)
+		items[i] = &Item{Key: key + suffix, Value: value}
+	}
+	return items
 }
 
 func BenchmarkSet(b *testing.B) {
@@ -68,6 +215,70 @@ func BenchmarkSetGet(b *testing.B) {
 
 func BenchmarkSetGetLarge(b *testing.B) {
 	benchmarkSetGet(b, largeItem())
+}
+
+func BenchmarkSetQuietly(b *testing.B) {
+	benchmarkSetQuietly(b, smallItem())
+}
+
+func BenchmarkSetQuietlyLarge(b *testing.B) {
+	benchmarkSetQuietly(b, largeItem())
+}
+
+func BenchmarkSetGetQuietly(b *testing.B) {
+	benchmarkSetGetQuietly(b, smallItem())
+}
+
+func BenchmarkSetGetQuietlyLarge(b *testing.B) {
+	benchmarkSetGetQuietly(b, largeItem())
+}
+
+func BenchmarkSetMultiSingle(b *testing.B) {
+	benchmarkSetMulti(b, generateSmallItems(1))
+}
+
+func BenchmarkSetMulti(b *testing.B) {
+	benchmarkSetMulti(b, generateSmallItems(10))
+}
+
+func BenchmarkSetMultiSingleLarge(b *testing.B) {
+	benchmarkSetMulti(b, generateLargeItems(1))
+}
+
+func BenchmarkSetMultiLarge(b *testing.B) {
+	benchmarkSetMulti(b, generateLargeItems(10))
+}
+
+func BenchmarkSetGetMulti(b *testing.B) {
+	benchmarkSetGetMulti(b, generateSmallItems(10))
+}
+
+func BenchmarkSetGetMultiLarge(b *testing.B) {
+	benchmarkSetGetMulti(b, generateLargeItems(10))
+}
+
+func BenchmarkSetMultiQuietlySingle(b *testing.B) {
+	benchmarkSetMultiQuietly(b, generateSmallItems(1))
+}
+
+func BenchmarkSetMultiQuietly(b *testing.B) {
+	benchmarkSetMultiQuietly(b, generateSmallItems(10))
+}
+
+func BenchmarkSetMultiQuietlySingleLarge(b *testing.B) {
+	benchmarkSetMultiQuietly(b, generateLargeItems(1))
+}
+
+func BenchmarkSetMultiQuietlyLarge(b *testing.B) {
+	benchmarkSetMultiQuietly(b, generateLargeItems(10))
+}
+
+func BenchmarkSetGetMultiQuietly(b *testing.B) {
+	benchmarkSetGetMultiQuietly(b, generateSmallItems(10))
+}
+
+func BenchmarkSetGetMultiQuietlyLarge(b *testing.B) {
+	benchmarkSetGetMultiQuietly(b, generateLargeItems(10))
 }
 
 func benchmarkConcurrentSetGet(b *testing.B, item *Item, count int, opcount int) {

--- a/memcache_test.go
+++ b/memcache_test.go
@@ -154,6 +154,19 @@ func testWithClient(t *testing.T, c *Client) {
 		t.Errorf("set(foo<0x7f>) should return ErrMalformedKey instead of %v", err)
 	}
 
+	// SetQuietly
+	quiet := &Item{Key: "quiet", Value: []byte("Shhh")}
+	err = c.SetQuietly(quiet)
+	checkErr(err, "setQuietly: %v", err)
+	it, err = c.Get(quiet.Key)
+	checkErr(err, "setQuietly: get: %v", err)
+	if it.Key != quiet.Key {
+		t.Errorf("setQuietly: get: Key = %q, want %s", it.Key, quiet.Key)
+	}
+	if string(it.Value) != string(quiet.Value) {
+		t.Errorf("setQuietly: get: Value = %q, want %q", string(it.Value), string(quiet.Value))
+	}
+
 	// Add
 	bar := &Item{Key: "bar", Value: []byte("barval")}
 	err = c.Add(bar)
@@ -179,6 +192,68 @@ func testWithClient(t *testing.T, c *Client) {
 	}
 	if g, e := string(m["bar"].Value), "barval"; g != e {
 		t.Errorf("GetMulti: bar: got %q, want %q", g, e)
+	}
+
+	// SetMulti
+	baz1 := &Item{Key: "baz1", Value: []byte("baz1val")}
+	baz2 := &Item{Key: "baz2", Value: []byte("baz2val"), Flags: 123}
+	err = c.SetMulti([]*Item{baz1, baz2})
+	checkErr(err, "first SetMulti: %v", err)
+	err = c.SetMulti([]*Item{baz1, baz2})
+	checkErr(err, "second SetMulti: %v", err)
+	m, err = c.GetMulti([]string{baz1.Key, baz2.Key})
+	checkErr(err, "SetMulti: %v", err)
+	if g, e := len(m), 2; g != e {
+		t.Errorf("SetMulti: got len(map) = %d, want = %d", g, e)
+	}
+	if _, ok := m[baz1.Key]; !ok {
+		t.Fatalf("SetMulti: didn't get key '%s'", baz1.Key)
+	}
+	if _, ok := m[baz2.Key]; !ok {
+		t.Fatalf("SetMulti: didn't get key '%s'", baz2.Key)
+	}
+	if g, e := string(m[baz1.Key].Value), string(baz1.Value); g != e {
+		t.Errorf("SetMulti: got %q, want %q", g, e)
+	}
+	if g, e := string(m[baz2.Key].Value), string(baz2.Value); g != e {
+		t.Errorf("SetMulti: got %q, want %q", g, e)
+	}
+	if m[baz1.Key].Flags != baz1.Flags {
+		t.Errorf("SetMulti: Flags = %v, want %v", m[baz1.Key].Flags, baz1.Flags)
+	}
+	if m[baz2.Key].Flags != baz2.Flags {
+		t.Errorf("SetMulti: Flags = %v, want %v", m[baz2.Key].Flags, baz2.Flags)
+	}
+
+	// SetMultiQuietly
+	quiet1 := &Item{Key: "quiet1", Value: []byte("quiet1val")}
+	quiet2 := &Item{Key: "quiet2", Value: []byte("quiet2val"), Flags: 123}
+	err = c.SetMulti([]*Item{quiet1, quiet2})
+	checkErr(err, "first SetMultiQuietly: %v", err)
+	err = c.SetMulti([]*Item{quiet1, quiet2})
+	checkErr(err, "second SetMultiQuietly: %v", err)
+	m, err = c.GetMulti([]string{quiet1.Key, quiet2.Key})
+	checkErr(err, "SetMultiQuietly: %v", err)
+	if g, e := len(m), 2; g != e {
+		t.Errorf("SetMultiQuietly: got len(map) = %d, want = %d", g, e)
+	}
+	if _, ok := m[quiet1.Key]; !ok {
+		t.Fatalf("SetMultiQuietly: didn't get key '%s'", quiet1.Key)
+	}
+	if _, ok := m[quiet2.Key]; !ok {
+		t.Fatalf("SetMultiQuietly: didn't get key '%s'", quiet2.Key)
+	}
+	if g, e := string(m[quiet1.Key].Value), string(quiet1.Value); g != e {
+		t.Errorf("SetMultiQuietly: got %q, want %q", g, e)
+	}
+	if g, e := string(m[quiet2.Key].Value), string(quiet2.Value); g != e {
+		t.Errorf("SetMultiQuietly: got %q, want %q", g, e)
+	}
+	if m[quiet1.Key].Flags != quiet1.Flags {
+		t.Errorf("SetMultiQuietly: Flags = %v, want %v", m[quiet1.Key].Flags, quiet1.Flags)
+	}
+	if m[quiet2.Key].Flags != quiet2.Flags {
+		t.Errorf("SetMultiQuietly: Flags = %v, want %v", m[quiet2.Key].Flags, quiet2.Flags)
 	}
 
 	// Delete


### PR DESCRIPTION
```
BenchmarkSet-4                                    100000             23149 ns/op           0.26 MB/s          40 B/op          2 allocs/op
BenchmarkSetLarge-4                               100000             25531 ns/op          49.51 MB/s         280 B/op          3 allocs/op
BenchmarkSetGet-4                                  30000             46708 ns/op           0.13 MB/s         144 B/op          6 allocs/op
BenchmarkSetGetLarge-4                             30000             51620 ns/op          24.49 MB/s        1648 B/op          8 allocs/op
BenchmarkSetQuietly-4                             300000              5476 ns/op           1.10 MB/s           8 B/op          1 allocs/op
BenchmarkSetQuietlyLarge-4                        200000              6648 ns/op         190.12 MB/s         248 B/op          2 allocs/op
BenchmarkSetGetQuietly-4                           50000             28961 ns/op           0.21 MB/s         112 B/op          5 allocs/op
BenchmarkSetGetQuietlyLarge-4                      50000             29832 ns/op          42.37 MB/s        1616 B/op          7 allocs/op
BenchmarkSetMultiSingle-4                         100000             22610 ns/op           0.35 MB/s          40 B/op          2 allocs/op
BenchmarkSetMulti-4                                10000            241119 ns/op           0.33 MB/s         680 B/op         18 allocs/op
BenchmarkSetMultiSingleLarge-4                    100000             24333 ns/op          51.95 MB/s         280 B/op          3 allocs/op
BenchmarkSetMultiLarge-4                            5000            244862 ns/op          51.62 MB/s        3080 B/op         28 allocs/op
BenchmarkSetGetMulti-4                              3000            407955 ns/op           0.20 MB/s        3257 B/op         90 allocs/op
BenchmarkSetGetMultiLarge-4                         3000            587605 ns/op          21.51 MB/s       22899 B/op        110 allocs/op
BenchmarkSetMultiQuietlySingle-4                  200000              7456 ns/op           1.07 MB/s           8 B/op          1 allocs/op
BenchmarkSetMultiQuietly-4                         20000             70834 ns/op           1.13 MB/s         360 B/op          8 allocs/op
BenchmarkSetMultiQuietlySingleLarge-4             200000              7452 ns/op         169.61 MB/s         248 B/op          2 allocs/op
BenchmarkSetMultiQuietlyLarge-4                    20000             82720 ns/op         152.80 MB/s        2760 B/op         18 allocs/op
BenchmarkSetGetMultiQuietly-4                       5000            268591 ns/op           0.30 MB/s        2935 B/op         80 allocs/op
BenchmarkSetGetMultiQuietlyLarge-4                  5000            291089 ns/op          43.42 MB/s       22578 B/op        100 allocs/op
BenchmarkGetCacheMiss-4                            50000             22588 ns/op              64 B/op          2 allocs/op
BenchmarkConcurrentSetGetSmall10_100-4                50          31706009 ns/op           0.19 MB/s      154918 B/op       6150 allocs/op
BenchmarkConcurrentSetGetLarge10_100-4                50          31407891 ns/op          40.24 MB/s     1659298 B/op       8161 allocs/op
BenchmarkConcurrentSetGetSmall20_100-4                20          56925995 ns/op           0.21 MB/s      314467 B/op      12354 allocs/op
BenchmarkConcurrentSetGetLarge20_100-4                20          65604962 ns/op          38.53 MB/s     3326486 B/op      16425 allocs/op
BenchmarkPickServer-4                           20000000                65.2 ns/op             0 B/op          0 allocs/op
BenchmarkPickServer_Single-4                    500000000                3.05 ns/op            0 B/op          0 allocs/op
PASS
```